### PR TITLE
change: fixed codec derive

### DIFF
--- a/fixed_codec_derive/src/decode.rs
+++ b/fixed_codec_derive/src/decode.rs
@@ -38,7 +38,7 @@ pub fn decode_unnamed_field(index: usize, field: &syn::Field, quotes: ParseQuote
 			if ident_type == "Vec" {
 				quote! { #list(#index)?, }
 			} else if ident_type == "Bytes" {
-				quote! { bytes::Bytes::from(rlp.val_at::<Vec<u8>>(#index)?), }
+				quote! { Bytes::from(rlp.val_at::<Vec<u8>>(#index)?), }
 			} else if ident_type == "String" {
 				let string = quote! { rlp.val_at::<String>(#index)? };
 				quote! { {
@@ -89,7 +89,7 @@ pub fn decode_field(index: usize, field: &syn::Field, quotes: ParseQuotes) -> To
 			if ident_type == "Vec" {
 				quote! { #id: #list(#index)?, }
 			} else if ident_type == "Bytes" {
-				quote! { #id: bytes::Bytes::from(rlp.val_at::<Vec<u8>>(#index)?), }
+				quote! { #id: Bytes::from(rlp.val_at::<Vec<u8>>(#index)?), }
 			} else {
 				quote! { #id: #single(#index)?, }
 			}

--- a/fixed_codec_derive/src/fixed_codec.rs
+++ b/fixed_codec_derive/src/fixed_codec.rs
@@ -15,12 +15,12 @@ pub fn impl_fixed_codec(ast: syn::DeriveInput) -> TokenStream {
 	let impl_encode = impl_encode(&name, body);
 	let impl_decode = impl_decode(&name, body);
 	let impl_muta = quote! {
-		impl muta_protocol::fixed_codec::FixedCodec for #name {
-			fn encode_fixed(&self) -> ProtocolResult<bytes::Bytes> {
-				Ok(bytes::Bytes::from(rlp::encode(self)))
+		impl FixedCodec for #name {
+			fn encode_fixed(&self) -> ProtocolResult<Bytes> {
+				Ok(Bytes::from(rlp::encode(self)))
 			}
 
-			fn decode_fixed(bytes: bytes::Bytes) -> ProtocolResult<Self> {
+			fn decode_fixed(bytes: Bytes) -> ProtocolResult<Self> {
 				Ok(rlp::decode(bytes.as_ref()).map_err(FixedCodecError::from)?)
 			}
 		}
@@ -29,9 +29,6 @@ pub fn impl_fixed_codec(ast: syn::DeriveInput) -> TokenStream {
 	quote! {
 		const _: () = {
 			extern crate rlp;
-			extern crate muta_protocol;
-
-			use muta_protocol::{fixed_codec::FixedCodecError, ProtocolResult, Bytes};
 
 			#impl_encode
 			#impl_decode

--- a/fixed_codec_derive/tests/mock_types.rs
+++ b/fixed_codec_derive/tests/mock_types.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::new_without_default)]
 
-use bytes::Bytes;
 use fixed_codec_derive::RlpFixedCodec;
+use muta_protocol::fixed_codec::{FixedCodec, FixedCodecError};
+use muta_protocol::{Bytes, ProtocolResult};
 use rand::random;
 
 const HASH_LEN: usize = 32;


### PR DESCRIPTION
This PR does:
* change `use muta_protocol::fixed_codec::FixedCodec` to `FixedCodec` in proc macro.